### PR TITLE
Fix lint errors in client/tests

### DIFF
--- a/ranger.go
+++ b/ranger.go
@@ -181,7 +181,12 @@ func (c *Client) UpdatePolicy(policy *Policy) (*Policy, error) {
 	if err != nil {
 		return nil, fmt.Errorf("error making update policy request to %s: %w", uri, err)
 	}
-	defer resp.Body.Close()
+
+	defer func() {
+		if err := resp.Body.Close(); err != nil {
+			fmt.Printf("error closing response body: %v\n", err)
+		}
+	}()
 
 	var updatedPolicy Policy
 	if err := json.NewDecoder(resp.Body).Decode(&updatedPolicy); err != nil {
@@ -203,7 +208,12 @@ func (c *Client) GetServices() ([]Service, error) {
 	if err != nil {
 		return nil, fmt.Errorf("error making get services request to %s: %w", uri, err)
 	}
-	defer resp.Body.Close()
+
+	defer func() {
+		if err := resp.Body.Close(); err != nil {
+			fmt.Printf("error closing response body: %v\n", err)
+		}
+	}()
 
 	var services []Service
 	if err := json.NewDecoder(resp.Body).Decode(&services); err != nil {

--- a/ranger.go
+++ b/ranger.go
@@ -61,7 +61,11 @@ func (c *Client) GetPolicy(policyId int) (*Policy, error) {
 		return nil, fmt.Errorf("error making get policy request to %s: %w", uri, err)
 	}
 
-	defer resp.Body.Close()
+	defer func() {
+		if err := resp.Body.Close(); err != nil {
+			fmt.Printf("error closing response body: %v\n", err)
+		}
+	}()
 
 	var policy Policy
 
@@ -94,7 +98,11 @@ func (c *Client) GetPolicies(serviceName ...string) ([]Policy, error) {
 		return nil, fmt.Errorf("error making get policies request to %s: %w", uri, err)
 	}
 
-	defer resp.Body.Close()
+	defer func() {
+		if err := resp.Body.Close(); err != nil {
+			fmt.Printf("error closing response body: %v\n", err)
+		}
+	}()
 
 	var policies []Policy
 
@@ -123,7 +131,12 @@ func (c *Client) CreatePolicy(p *Policy) (*Policy, error) {
 	if err != nil {
 		return nil, fmt.Errorf("error making create policy request to %s: %w", uri, err)
 	}
-	defer resp.Body.Close()
+
+	defer func() {
+		if err := resp.Body.Close(); err != nil {
+			fmt.Printf("error closing response body: %v\n", err)
+		}
+	}()
 
 	var createdPolicy Policy
 	if err := json.NewDecoder(resp.Body).Decode(&createdPolicy); err != nil {

--- a/ranger_test.go
+++ b/ranger_test.go
@@ -67,7 +67,9 @@ func GetFakeRangerServer() *httptest.Server {
 				err := json.NewDecoder(r.Body).Decode(&newPolicy)
 				if err != nil {
 					w.WriteHeader(http.StatusBadRequest)
-					fmt.Fprintf(w, "Bad Request: %v", err)
+					if _, writeErr := fmt.Fprintf(w, "Bad Request: %v", err); writeErr != nil {
+						fmt.Printf("Error writing response: %v", writeErr)
+					}
 					return
 				}
 
@@ -98,7 +100,9 @@ func GetFakeRangerServer() *httptest.Server {
 				err := json.NewDecoder(r.Body).Decode(&policyToUpdate)
 				if err != nil {
 					w.WriteHeader(http.StatusBadRequest)
-					fmt.Fprintf(w, "Bad Request: %v", err)
+					if _, writeErr := fmt.Fprintf(w, "Bad Request: %v", err); writeErr != nil {
+						fmt.Printf("Error writing response: %v", writeErr)
+					}
 					return
 				}
 


### PR DESCRIPTION
## Description

Fix linting by ensuring that errors generated from both `resp.Body.Close` and `fmt.Fprintf` are handled. Logging these errors is sufficient - in reality the call to `Close()` very rarely errors, and when it does the http client should clean it up.

## Related Issue

Link to any related issue (if applicable): n/a

## Checklist

- [x] Tests added/updated
- [x] Documentation updated (if needed)

## Reviewer Notes

Check the CI passes the lint checks.
