### PR TITLE
Fix Go workflow default branch filters

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -5,9 +5,9 @@ name: Go
 
 on:
   push:
-    branches: [ "master" ]
+    branches: [ "main" ]
   pull_request:
-    branches: [ "master" ]
+    branches: [ "main" ]
 
 jobs:
 


### PR DESCRIPTION
## Summary
- update the primary Go workflow push and pull-request filters from stale `master` to default `main`
- keep the existing formatting, vet, build, and test steps unchanged

## Remote Linux validation
- `git diff --check`
- `gofmt -s -w . && git diff --exit-code`
- `go vet ./...`
- `go build -v ./...`
- `go test -v ./...`