### PR TITLE
Fix lint CI: bump golangci-lint to v2.12 (Go 1.26 compat)

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -21,4 +21,4 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v8
         with:
-          version: v2.1
+          version: v2.12


### PR DESCRIPTION
## What

Bump the golangci-lint version from `v2.1` to `v2.12` in `golangci-lint.yml`.

## Why

The `lint` job crashes (panics, not a lint finding):

```
panic: file requires newer Go version go1.26 (application built with go1.24)
```

The workflow installs golangci-lint `v2.1` (its latest patch `v2.1.6` was built with Go 1.24), but `actions/setup-go` with `go-version: stable` now provides **Go 1.26**, so golangci-lint can no longer parse the toolchain's std/types and the type-checker panics. Bumping to `v2.12` (built with a current Go toolchain) resolves the incompatibility.

## Notes

- Draft pending CI. A newer golangci-lint may surface additional lint findings; if so, those are addressed separately from this CI-unblock.